### PR TITLE
Fix OpenSSL for Ruby 2.3.8

### DIFF
--- a/bin/setup-linux-workstation.sh
+++ b/bin/setup-linux-workstation.sh
@@ -14,10 +14,10 @@ su -c "sed -i '/deb cdrom/d' /etc/apt/sources.list"
 su -c "apt-get update && apt-get install curl -y"
 
 # download and install chefdk
-chef_dk_file="Downloads/chefdk_3.8.14-1_amd64.deb"
+chef_dk_file="Downloads/chefdk_4.0.60-1_amd64.deb"
 
 if [ ! -f "$chef_dk_file" ]; then
-    wget -O $chef_dk_file https://packages.chef.io/files/stable/chefdk/3.8.14/debian/9/chefdk_3.8.14-1_amd64.deb
+    wget -O $chef_dk_file https://packages.chef.io/files/stable/chefdk/4.0.60/debian/9/chefdk_4.0.60-1_amd64.deb
 fi
 
 su -c "dpkg -i $chef_dk_file"

--- a/chef/.kitchen.yml
+++ b/chef/.kitchen.yml
@@ -4,6 +4,8 @@ driver:
 
 provisioner:
   name: chef_solo
+  product_name: chef
+  product_version: 14.12.3
 
 verifier:
   name: inspec

--- a/chef/recipes/default.rb
+++ b/chef/recipes/default.rb
@@ -49,6 +49,7 @@ include_recipe 'linux-workstation::jq'
 include_recipe 'linux-workstation::unzip'
 include_recipe 'linux-workstation::dtrx'
 include_recipe 'linux-workstation::xbacklight'
+include_recipe 'linux-workstation::openssl'
 
 # Configs
 #   individual config files, etc - should be handled by vault + individual dot files

--- a/chef/recipes/openssl.rb
+++ b/chef/recipes/openssl.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: linux-workstation
+# Recipe:: openssl
+#
+# TODO verify licence
+# Copyright 2019, Contently
+#
+# All rights reserved - Do Not Redistribute
+#
+# Debugging - uncomment next two lines
+# chef_gem 'pry'
+# require 'pry'
+#
+
+include_recipe 'linux-workstation::apt'
+
+apt_package 'libssl1.0-dev'


### PR DESCRIPTION
* Update chef / kitchen version due to bugs in running tests. 
* Add openssl package update.